### PR TITLE
fix: add install target to cmake

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -31,3 +31,4 @@ add_executable(${EXECUTABLE_NAME}
 )
 
 target_link_libraries(${EXECUTABLE_NAME} hidragui)
+install(TARGETS ${PROJECT_NAME})


### PR DESCRIPTION
Adds the install target to CMake, placing the compiled `hidracpp` binary on the machine's $PATH after installation.